### PR TITLE
feat: Auto-caching responses

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserModule } from './user/user.module';
 import { PokerModule } from './poker/poker.module';
 import { DatabaseModule } from './database/database.module';
-import { CacheModule } from '@nestjs/cache-manager';
+import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
 import { OauthModule } from './oauth/oauth.module';
 import { ProblemModule } from './problem/problem.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -17,6 +18,12 @@ import { ProblemModule } from './problem/problem.module';
     DatabaseModule,
     OauthModule,
     ProblemModule,
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CacheInterceptor,
+    },
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
속도 이슈의 근본적인 문제를 타파하고자
[GET 요청에 대한 글로벌 캐싱](https://docs.nestjs.com/techniques/caching#auto-caching-responses)을 적용함

로컬 기준 1초대에서 10ms 단위로 속도 차이 쩌는 거 확인
